### PR TITLE
 Add better ray box intersection

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -92,14 +92,19 @@ pub const XZ_PLANE: Plane = Plane {
 pub struct Ray {
     pub origin: Vector3<f32>,
     pub end: Vector3<f32>,
+    pub inv_len: Vector3<f32>,
     vector: Vector3<f32>,
 }
 
 impl Ray {
     pub fn new(origin: Vector3<f32>, end: Vector3<f32>) -> Self {
+
+        let vector = origin - end;
+
         Ray {
             origin,
-            vector: origin - end,
+            vector,
+            inv_len: 1.0 / vector,
             end,
         }
     }
@@ -398,8 +403,8 @@ pub fn ray_box_intersection(bbox: &BoundingBox, ray: &Ray, dist: &mut f32) -> bo
     let mut tmax = f32::INFINITY;
 
     for i in 0..3 {
-        let t1 = (bbox.corner[i] - ray.origin[i]) / (ray.end[i] - ray.origin[i]);
-        let t2 = (bbox.vec_max()[i] - ray.origin[i]) / (ray.end[i] - ray.origin[i]);
+        let t1 = (bbox.corner[i] - ray.origin[i]) * ray.inv_len[i];
+        let t2 = (bbox.vec_max()[i] - ray.origin[i]) * ray.inv_len[i];
 
         tmin = tmin.max(t1.min(t2));
         tmax = tmax.min(t1.max(t2));

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -120,11 +120,11 @@ impl Ray {
         let mut tmin = f32::NEG_INFINITY;
         let mut tmax = f32::INFINITY;
 
-        let dir = 1.0 / self.vector;
+        let inv_dir = 1.0 / -self.vector;
 
         for i in 0..3 {
-            let t1 = (bbox.corner[i] - self.origin[i]) * dir[i];
-            let t2 = (bbox.vec_max()[i] - self.origin[i]) * dir[i];
+            let t1 = (bbox.corner[i] - self.origin[i]) * inv_dir[i];
+            let t2 = (bbox.vec_max()[i] - self.origin[i]) * inv_dir[i];
 
             tmin = tmin.max(t1.min(t2));
             tmax = tmax.min(t1.max(t2));
@@ -423,15 +423,17 @@ mod tests {
         let origin     = Vector3::new(0.0, 0.0, 0.0);
         let ray_dir    = Vector3::new(1.0, 0.0, 0.0);
         let box_extent = Vector3::new(1.0, 1.0, 1.0);
-        let box_corner = Vector3::new(0.0, -0.5, -0.5);
+        let box_corner = Vector3::new(1.0, -0.5, -0.5);
 
         let ray = Ray::new(origin, ray_dir);
         let bb  = BoundingBox::new(box_corner,
                                    box_extent,
                                    black);
 
-        let mut dist = 0.0;
+        let expected_dist = box_corner.x.abs() + box_corner.y.abs() + box_corner.z.abs(); // Manhattan distance
+        let mut dist      = 0.0;
+
         assert!( ray.box_intersection(&bb, &mut dist) );
-        assert_eq!( dist, 1.0 );
+        assert_eq!( dist, expected_dist );
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -408,3 +408,28 @@ pub fn ray_box_intersection(bbox: &BoundingBox, ray: &Ray, dist: &mut f32) -> bo
     *dist = BoundingBox::manhattan_distance(&ray.origin, &bbox.corner);
     tmax >= tmin.max(0.0)
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn ray_box_intersection() {
+
+        let black      = [0.0, 0.0, 0.0, 1.0];
+        let origin     = Vector3::new(0.0, 0.0, 0.0);
+        let ray_dir    = Vector3::new(1.0, 0.0, 0.0);
+        let box_extent = Vector3::new(1.0, 1.0, 1.0);
+        let box_corner = Vector3::new(0.0, -0.5, -0.5);
+
+        let ray = Ray::new(origin, ray_dir);
+        let bb  = BoundingBox::new(box_corner,
+                                   box_extent,
+                                   black);
+
+        let mut dist = 0.0;
+        assert!( super::ray_box_intersection(&bb, &ray, &mut dist) );
+        assert_eq!( dist, 1.0 );
+    }
+}

--- a/src/voxel_manager.rs
+++ b/src/voxel_manager.rs
@@ -1,4 +1,4 @@
-use crate::geometry::{ray_box_intersection, BoundingBox, Ray};
+use crate::geometry::{BoundingBox, Ray};
 use crate::vertex::{instance, VoxelInstance, VoxelVertex};
 use cgmath::Vector3;
 
@@ -166,7 +166,7 @@ impl VoxelManager {
                             color,
                         );
 
-                        if ray_box_intersection(&bbox, ray, &mut distance) {
+                        if ray.box_intersection(&bbox, &mut distance) {
                             if distance.abs() < closest_distance {
                                 closest_distance = distance.abs();
                                 erase_box = Some(bbox);
@@ -189,7 +189,7 @@ impl VoxelManager {
                 bbox.corner.z as usize,
             );
             for bbox in boxes {
-                if ray_box_intersection(&bbox, ray, &mut distance) {
+                if ray.box_intersection(&bbox, &mut distance) {
                     if distance.abs() < closest_distance {
                         closest_distance = distance.abs();
                         draw_box = Some(bbox);


### PR DESCRIPTION
Implementation for issue #7 

I made a small refactoring because I didn't see the reason why `ray_box_intersection` shouldn't be a Ray member function as `plane_intersection`.
This way we also get rid of the need for a new `inverse_length` member, since we already have `vector`.
However, I've made this in a separated commit in case you prefer to stick with the original approach.

I added a small unit test too to make sure I didn't break anything.