### PR TITLE
Show edit box when the cursor leaves editor surface

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -418,22 +418,19 @@ mod tests {
 
     #[test]
     fn ray_box_intersection() {
-
-        let black      = [0.0, 0.0, 0.0, 1.0];
-        let origin     = Vector3::new(0.0, 0.0, 0.0);
-        let ray_dir    = Vector3::new(1.0, 0.0, 0.0);
+        let black = [0.0, 0.0, 0.0, 1.0];
+        let origin = Vector3::new(0.0, 0.0, 0.0);
+        let ray_dir = Vector3::new(1.0, 0.0, 0.0);
         let box_extent = Vector3::new(1.0, 1.0, 1.0);
         let box_corner = Vector3::new(1.0, -0.5, -0.5);
 
         let ray = Ray::new(origin, ray_dir);
-        let bb  = BoundingBox::new(box_corner,
-                                   box_extent,
-                                   black);
+        let bb = BoundingBox::new(box_corner, box_extent, black);
 
         let expected_dist = box_corner.x.abs() + box_corner.y.abs() + box_corner.z.abs(); // Manhattan distance
-        let mut dist      = 0.0;
+        let mut dist = 0.0;
 
-        assert!( ray.box_intersection(&bb, &mut dist) );
-        assert_eq!( dist, expected_dist );
+        assert!(ray.box_intersection(&bb, &mut dist));
+        assert_eq!(dist, expected_dist);
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -799,10 +799,8 @@ impl Renderer {
                 &mut self.command_buffers,
             );
             self.draw_cube = Some(draw_cube);
-            self.render_cursor = true;
-        } else {
-            self.render_cursor = false;
         }
+        self.render_cursor = true;
     }
 
     pub fn update_draw_rectangle(&mut self, mut bbox: BoundingBox) {


### PR DESCRIPTION
Previsouly this was confusing, because the edit box was still alive, but there was no visible clue for that.
I deciced to keep the edit box, when the cursor leaves the editable surface, because if someone accidently goes out of bounds with the mouse, it would be annoying to start the editing again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zakorgy/voxel-editor/27)
<!-- Reviewable:end -->
