### PR TITLE
Disable drawing when the cursor is over the UI

### DIFF
--- a/src/controls.rs
+++ b/src/controls.rs
@@ -181,10 +181,11 @@ pub struct Controls {
     export_file: Cell<Option<String>>,
     save_file: Cell<Option<String>>,
     load_file: Cell<Option<String>>,
+    width: u16,
 }
 
 impl Controls {
-    pub fn new() -> Controls {
+    pub fn new(width: u16) -> Controls {
         Controls {
             edit_op: Cell::new(EditOp::default()),
             export_button: button::State::default(),
@@ -195,6 +196,7 @@ impl Controls {
             export_file: Cell::new(None),
             save_file: Cell::new(None),
             load_file: Cell::new(None),
+            width,
         }
     }
 
@@ -260,7 +262,7 @@ impl Program for Controls {
             .iter()
             .fold(
                 Column::new()
-                    .width(Length::Units(150))
+                    .width(Length::Units(self.width))
                     .spacing(10)
                     .push(Text::new("Edit state (Press space to step):")),
                 |column, state| {
@@ -290,7 +292,7 @@ impl Program for Controls {
             );
 
         Container::new(edit_bar)
-            .width(Length::Units(150))
+            .width(Length::Units(self.width))
             .height(Length::Fill)
             .padding(10)
             .style(UiStyle {})

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -50,6 +50,9 @@ impl Editor {
 
     fn update(&mut self, event: winit::event::WindowEvent) {
         self.ui.update(&event, self.window.scale_factor());
+        if self.ui.is_cursor_over_ui {
+            return;
+        }
         // Don't change the view if we're editing the 3d canvas
         if let event::WindowEvent::MouseInput {
             state,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,10 +14,13 @@ pub struct Ui {
     viewport: Viewport,
     cursor_position: PhysicalPosition<f64>,
     modifiers: ModifiersState,
+    width: u16,
+    pub is_cursor_over_ui: bool,
 }
 
 impl Ui {
     pub fn new(window: &Window, device: &mut wgpu::Device) -> Ui {
+        let width = 150;
         let physical_size = window.inner_size();
         let viewport = Viewport::with_physical_size(
             Size::new(physical_size.width, physical_size.height),
@@ -26,7 +29,7 @@ impl Ui {
         let cursor_position = PhysicalPosition::new(-1.0, -1.0);
         let modifiers = ModifiersState::default();
 
-        let controls = Controls::new();
+        let controls = Controls::new(width);
         let mut debug = Debug::new();
         let mut renderer = Renderer::new(Backend::new(device, Settings::default()));
 
@@ -45,6 +48,8 @@ impl Ui {
             viewport,
             cursor_position,
             modifiers,
+            width,
+            is_cursor_over_ui: false,
         }
     }
 
@@ -72,6 +77,11 @@ impl Ui {
         }
         match *event {
             WindowEvent::CursorMoved { position, .. } => {
+                if position.x > self.width as f64 {
+                    self.is_cursor_over_ui = false;
+                } else {
+                    self.is_cursor_over_ui = true;
+                }
                 self.cursor_position = position;
             }
             WindowEvent::ModifiersChanged(new_modifiers) => {


### PR DESCRIPTION
When the cursor is over the UI, it still can draw voxels on the editor grid. This MR fixes that issue, by disabling the editing action, if the cursor is over the UI.